### PR TITLE
Update router-config.yaml for router v2

### DIFF
--- a/router/router-config.yaml
+++ b/router/router-config.yaml
@@ -6,4 +6,4 @@ coprocessor:
   url: http://localhost:3007
   supergraph:
     request:
-      context: true
+      context: all


### PR DESCRIPTION
update context from true to all because true is deprecated in v2 and if set, will send old var names